### PR TITLE
Fix the Build Properties

### DIFF
--- a/JellyfinTray.csproj
+++ b/JellyfinTray.csproj
@@ -7,6 +7,7 @@
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <ApplicationIcon>JellyfinIcon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
+	<PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/JellyfinTray.csproj
+++ b/JellyfinTray.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ApplicationIcon>JellyfinIcon.ico</ApplicationIcon>
     <PublishTrimmed>true</PublishTrimmed>
 	<PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
Sets the correct runtime identifier, and sets PublishSingleFile to true for this project.

To deploy/build: `dotnet publish -c Release`